### PR TITLE
Simplifies extension imports

### DIFF
--- a/extension/index.js
+++ b/extension/index.js
@@ -1,17 +1,12 @@
-"use strict";
-
-const achievements = require("./achievements");
-const checkpoints = require("./checkpoints");
-const events = require("./events");
-const guests = require("./guests");
-const tiltify = require("./tiltify");
-const chatbot = require("./chatbot");
-
 module.exports = (nodecg) => {
-  achievements(nodecg);
-  checkpoints(nodecg);
-  events(nodecg);
-  guests(nodecg);
-  tiltify(nodecg);
-  chatbot(nodecg);
-};
+  [
+    'achievements',
+    'checkpoints',
+    'events',
+    'guests',
+    'tiltify',
+    'chatbot'
+  ].forEach(
+    module => require(`./${module}`)(nodecg)
+  )
+}


### PR DESCRIPTION
Could go one step further and look for all non-index files in the `extension` folder (except index) but that might be one step too far.

(Also, could be problematic if you're trying to test certain files)